### PR TITLE
useTransactioinでエラーが出るため、一旦戻し

### DIFF
--- a/nextjs/nextjs-routes.d.ts
+++ b/nextjs/nextjs-routes.d.ts
@@ -160,7 +160,7 @@ declare module "next/router" {
         | "defaultLocale"
         | "domainLocales"
       > & {
-        defaultLocale: "ja";
+        defaultLocale: "en";
         domainLocales?: undefined;
         locale: Locale;
         locales: [

--- a/ui/home/indicators/ChainIndicators.tsx
+++ b/ui/home/indicators/ChainIndicators.tsx
@@ -10,9 +10,9 @@ import IconSvg from 'ui/shared/IconSvg';
 import ChainIndicatorChartContainer from './ChainIndicatorChartContainer';
 import ChainIndicatorItem from './ChainIndicatorItem';
 import useFetchChartData from './useFetchChartData';
-import Indicators from './utils/indicators';
+import INDICATORS from './utils/indicators';
 
-const indicators = Indicators()
+const indicators = INDICATORS
   .filter(({ id }) => config.UI.homepage.charts.includes(id))
   .sort((a, b) => {
     if (config.UI.homepage.charts.indexOf(a.id) > config.UI.homepage.charts.indexOf(b.id)) {

--- a/ui/home/indicators/utils/indicators.tsx
+++ b/ui/home/indicators/utils/indicators.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { useTranslation } from 'react-i18next';
 
 import type { TChainIndicator } from '../types';
 import type { TimeChartItem, TimeChartItemRaw } from 'ui/shared/chart/types';
@@ -20,150 +19,144 @@ const nonNullTailReducer = (result: Array<TimeChartItemRaw>, item: TimeChartItem
 
 const mapNullToZero: (item: TimeChartItemRaw) => TimeChartItem = (item) => ({ ...item, value: Number(item.value) });
 
-const Indicators = () => {
-  const { t } = useTranslation();
-
-  const dailyTxsIndicator: TChainIndicator<'stats_charts_txs'> = {
-    id: 'daily_txs',
-    title: t('indicators.dailyTxs'),
-    value: (stats) => stats.transactions_today === null ?
-      'N/A' :
-      Number(stats.transactions_today).toLocaleString(undefined, { maximumFractionDigits: 2, notation: 'compact' }),
-    icon: <IconSvg name="transactions" boxSize={ 6 } bgColor="#56ACD1" borderRadius="base" color="white"/>,
-    hint: `Number of transactions yesterday (0:00 - 23:59 UTC). The chart displays daily transactions for the past 30 days.`,
-    api: {
-      resourceName: 'stats_charts_txs',
-      dataFn: (response) => ([ {
-        items: response.chart_data
-          .map((item) => ({ date: new Date(item.date), value: item.tx_count }))
-          .sort(sortByDateDesc)
-          .reduceRight(nonNullTailReducer, [] as Array<TimeChartItemRaw>)
-          .map(mapNullToZero),
-        name: 'Tx/day',
-        valueFormatter: (x: number) => x.toLocaleString(undefined, { maximumFractionDigits: 2, notation: 'compact' }),
-      } ]),
-    },
-  };
-
-  const coinPriceIndicator: TChainIndicator<'stats_charts_market'> = {
-    id: 'coin_price',
-    title: t('indicators.coinPrice', { symbol: config.chain.currency.symbol }),
-    value: (stats) => stats.coin_price === null ?
-      '$N/A' :
-      '$' + Number(stats.coin_price).toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 6 }),
-    valueDiff: (stats) => stats?.coin_price !== null ? stats?.coin_price_change_percentage : null,
-    icon: <NativeTokenIcon boxSize={ 6 }/>,
-    hint: `${ config.chain.currency.symbol } token daily price in USD.`,
-    api: {
-      resourceName: 'stats_charts_market',
-      dataFn: (response) => ([ {
-        items: response.chart_data
-          .map((item) => ({ date: new Date(item.date), value: item.closing_price }))
-          .sort(sortByDateDesc)
-          .reduceRight(nonNullTailReducer, [] as Array<TimeChartItemRaw>)
-          .map(mapNullToZero),
-        name: `${ config.chain.currency.symbol } price`,
-        valueFormatter: (x: number) => '$' + x.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 6 }),
-      } ]),
-    },
-  };
-
-  const secondaryCoinPriceIndicator: TChainIndicator<'stats_charts_secondary_coin_price'> = {
-    id: 'secondary_coin_price',
-    title: t('indicators.secondaryCoinPrice', { symbol: config.chain.secondaryCoin.symbol }),
-    value: (stats) => !stats.secondary_coin_price || stats.secondary_coin_price === null ?
-      '$N/A' :
-      '$' + Number(stats.secondary_coin_price).toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 6 }),
-    valueDiff: () => null,
-    icon: <TokenLogoPlaceholder boxSize={ 6 }/>,
-    hint: `${ config.chain.secondaryCoin.symbol } token daily price in USD.`,
-    api: {
-      resourceName: 'stats_charts_secondary_coin_price',
-      dataFn: (response) => ([ {
-        items: response.chart_data
-          .map((item) => ({ date: new Date(item.date), value: item.closing_price }))
-          .sort(sortByDateDesc)
-          .reduceRight(nonNullTailReducer, [] as Array<TimeChartItemRaw>)
-          .map(mapNullToZero),
-        name: `${ config.chain.secondaryCoin.symbol } price`,
-        valueFormatter: (x: number) => '$' + x.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 6 }),
-      } ]),
-    },
-  };
-
-  const marketPriceIndicator: TChainIndicator<'stats_charts_market'> = {
-    id: 'market_cap',
-    title: t('indicators.marketCap'),
-    value: (stats) => stats.market_cap === null ?
-      '$N/A' :
-      '$' + Number(stats.market_cap).toLocaleString(undefined, { maximumFractionDigits: 2, notation: 'compact' }),
-    icon: <IconSvg name="globe" boxSize={ 6 } bgColor="#6A5DCC" borderRadius="base" color="white"/>,
-    // eslint-disable-next-line max-len
-    hint: 'The total market value of a cryptocurrency\'s circulating supply. It is analogous to the free-float capitalization in the stock market. Market Cap = Current Price x Circulating Supply.',
-    api: {
-      resourceName: 'stats_charts_market',
-      dataFn: (response) => ([ {
-        items: response.chart_data
-          .map((item) => (
-            {
-              date: new Date(item.date),
-              value: (() => {
-                if (item.market_cap !== undefined) {
-                  return item.market_cap;
-                }
-
-                if (item.closing_price === null) {
-                  return null;
-                }
-
-                return Number(item.closing_price) * Number(response.available_supply);
-              })(),
-            }))
-          .sort(sortByDateDesc)
-          .reduceRight(nonNullTailReducer, [] as Array<TimeChartItemRaw>)
-          .map(mapNullToZero),
-        name: 'Market cap',
-        valueFormatter: (x: number) => '$' + x.toLocaleString(undefined, { maximumFractionDigits: 2 }),
-      } ]),
-    },
-  };
-
-  const tvlIndicator: TChainIndicator<'stats_charts_market'> = {
-    id: 'tvl',
-    title: t('indicators.tvl'),
-    value: (stats) => stats.tvl === null ?
-      '$N/A' :
-      '$' + Number(stats.tvl).toLocaleString(undefined, { maximumFractionDigits: 2, notation: 'compact' }),
-    icon: <IconSvg name="lock" boxSize={ 6 } bgColor="#517FDB" borderRadius="base" color="white"/>,
-    // eslint-disable-next-line max-len
-    hint: 'Total value of digital assets locked or staked in a chain',
-    api: {
-      resourceName: 'stats_charts_market',
-      dataFn: (response) => ([ {
-        items: response.chart_data
-          .map((item) => (
-            {
-              date: new Date(item.date),
-              value: item.tvl !== undefined ? item.tvl : 0,
-            }))
-          .sort(sortByDateDesc)
-          .reduceRight(nonNullTailReducer, [] as Array<TimeChartItemRaw>)
-          .map(mapNullToZero),
-        name: 'TVL',
-        valueFormatter: (x: number) => '$' + x.toLocaleString(undefined, { maximumFractionDigits: 2, notation: 'compact' }),
-      } ]),
-    },
-  };
-
-  const indicators = [
-    dailyTxsIndicator,
-    coinPriceIndicator,
-    secondaryCoinPriceIndicator,
-    marketPriceIndicator,
-    tvlIndicator,
-  ];
-
-  return indicators;
+const dailyTxsIndicator: TChainIndicator<'stats_charts_txs'> = {
+  id: 'daily_txs',
+  title: 'Daily transactions',
+  value: (stats) => stats.transactions_today === null ?
+    'N/A' :
+    Number(stats.transactions_today).toLocaleString(undefined, { maximumFractionDigits: 2, notation: 'compact' }),
+  icon: <IconSvg name="transactions" boxSize={ 6 } bgColor="#56ACD1" borderRadius="base" color="white"/>,
+  hint: `Number of transactions yesterday (0:00 - 23:59 UTC). The chart displays daily transactions for the past 30 days.`,
+  api: {
+    resourceName: 'stats_charts_txs',
+    dataFn: (response) => ([ {
+      items: response.chart_data
+        .map((item) => ({ date: new Date(item.date), value: item.tx_count }))
+        .sort(sortByDateDesc)
+        .reduceRight(nonNullTailReducer, [] as Array<TimeChartItemRaw>)
+        .map(mapNullToZero),
+      name: 'Tx/day',
+      valueFormatter: (x: number) => x.toLocaleString(undefined, { maximumFractionDigits: 2, notation: 'compact' }),
+    } ]),
+  },
 };
 
-export default Indicators;
+const coinPriceIndicator: TChainIndicator<'stats_charts_market'> = {
+  id: 'coin_price',
+  title: `${ config.chain.currency.symbol } price`,
+  value: (stats) => stats.coin_price === null ?
+    '$N/A' :
+    '$' + Number(stats.coin_price).toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 6 }),
+  valueDiff: (stats) => stats?.coin_price !== null ? stats?.coin_price_change_percentage : null,
+  icon: <NativeTokenIcon boxSize={ 6 }/>,
+  hint: `${ config.chain.currency.symbol } token daily price in USD.`,
+  api: {
+    resourceName: 'stats_charts_market',
+    dataFn: (response) => ([ {
+      items: response.chart_data
+        .map((item) => ({ date: new Date(item.date), value: item.closing_price }))
+        .sort(sortByDateDesc)
+        .reduceRight(nonNullTailReducer, [] as Array<TimeChartItemRaw>)
+        .map(mapNullToZero),
+      name: `${ config.chain.currency.symbol } price`,
+      valueFormatter: (x: number) => '$' + x.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 6 }),
+    } ]),
+  },
+};
+
+const secondaryCoinPriceIndicator: TChainIndicator<'stats_charts_secondary_coin_price'> = {
+  id: 'secondary_coin_price',
+  title: `${ config.chain.secondaryCoin.symbol } price`,
+  value: (stats) => !stats.secondary_coin_price || stats.secondary_coin_price === null ?
+    '$N/A' :
+    '$' + Number(stats.secondary_coin_price).toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 6 }),
+  valueDiff: () => null,
+  icon: <TokenLogoPlaceholder boxSize={ 6 }/>,
+  hint: `${ config.chain.secondaryCoin.symbol } token daily price in USD.`,
+  api: {
+    resourceName: 'stats_charts_secondary_coin_price',
+    dataFn: (response) => ([ {
+      items: response.chart_data
+        .map((item) => ({ date: new Date(item.date), value: item.closing_price }))
+        .sort(sortByDateDesc)
+        .reduceRight(nonNullTailReducer, [] as Array<TimeChartItemRaw>)
+        .map(mapNullToZero),
+      name: `${ config.chain.secondaryCoin.symbol } price`,
+      valueFormatter: (x: number) => '$' + x.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 6 }),
+    } ]),
+  },
+};
+
+const marketPriceIndicator: TChainIndicator<'stats_charts_market'> = {
+  id: 'market_cap',
+  title: 'Market cap',
+  value: (stats) => stats.market_cap === null ?
+    '$N/A' :
+    '$' + Number(stats.market_cap).toLocaleString(undefined, { maximumFractionDigits: 2, notation: 'compact' }),
+  icon: <IconSvg name="globe" boxSize={ 6 } bgColor="#6A5DCC" borderRadius="base" color="white"/>,
+  // eslint-disable-next-line max-len
+  hint: 'The total market value of a cryptocurrency\'s circulating supply. It is analogous to the free-float capitalization in the stock market. Market Cap = Current Price x Circulating Supply.',
+  api: {
+    resourceName: 'stats_charts_market',
+    dataFn: (response) => ([ {
+      items: response.chart_data
+        .map((item) => (
+          {
+            date: new Date(item.date),
+            value: (() => {
+              if (item.market_cap !== undefined) {
+                return item.market_cap;
+              }
+
+              if (item.closing_price === null) {
+                return null;
+              }
+
+              return Number(item.closing_price) * Number(response.available_supply);
+            })(),
+          }))
+        .sort(sortByDateDesc)
+        .reduceRight(nonNullTailReducer, [] as Array<TimeChartItemRaw>)
+        .map(mapNullToZero),
+      name: 'Market cap',
+      valueFormatter: (x: number) => '$' + x.toLocaleString(undefined, { maximumFractionDigits: 2 }),
+    } ]),
+  },
+};
+
+const tvlIndicator: TChainIndicator<'stats_charts_market'> = {
+  id: 'tvl',
+  title: 'Total value locked',
+  value: (stats) => stats.tvl === null ?
+    '$N/A' :
+    '$' + Number(stats.tvl).toLocaleString(undefined, { maximumFractionDigits: 2, notation: 'compact' }),
+  icon: <IconSvg name="lock" boxSize={ 6 } bgColor="#517FDB" borderRadius="base" color="white"/>,
+  // eslint-disable-next-line max-len
+  hint: 'Total value of digital assets locked or staked in a chain',
+  api: {
+    resourceName: 'stats_charts_market',
+    dataFn: (response) => ([ {
+      items: response.chart_data
+        .map((item) => (
+          {
+            date: new Date(item.date),
+            value: item.tvl !== undefined ? item.tvl : 0,
+          }))
+        .sort(sortByDateDesc)
+        .reduceRight(nonNullTailReducer, [] as Array<TimeChartItemRaw>)
+        .map(mapNullToZero),
+      name: 'TVL',
+      valueFormatter: (x: number) => '$' + x.toLocaleString(undefined, { maximumFractionDigits: 2, notation: 'compact' }),
+    } ]),
+  },
+};
+
+const INDICATORS = [
+  dailyTxsIndicator,
+  coinPriceIndicator,
+  secondaryCoinPriceIndicator,
+  marketPriceIndicator,
+  tvlIndicator,
+];
+
+export default INDICATORS;


### PR DESCRIPTION
## Description and Related Issue(s)

*[Provide a brief description of the changes or enhancements introduced by this pull request and explain motivation behind them. Cite any related issue(s) or bug(s) that it addresses using the [format](https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/) `Fixes #123` or `Resolves #456`.]*

### Proposed Changes
*[Specify the changes or additions made in this pull request. Please mention if any changes were made to the ENV variables]*

### Breaking or Incompatible Changes
*[Describe any breaking or incompatible changes introduced by this pull request. Specify how users might need to modify their code or configurations to accommodate these changes.]*

### Additional Information
*[Include any additional information, context, or screenshots that may be helpful for reviewers.]*

## Checklist for PR author
- [ ] I have tested these changes locally.
- [ ] I added tests to cover any new functionality, following this [guide](./CONTRIBUTING.md#writing--running-tests)
- [ ] Whenever I fix a bug, I include a regression test to ensure that the bug does not reappear silently.
- [ ] If I have added, changed, renamed, or removed an environment variable
    - I updated the list of environment variables in the [documentation](ENVS.md) 
    - I made the necessary changes to the validator script according to the [guide](./CONTRIBUTING.md#adding-new-env-variable)
    - I added "ENVs" label to this pull request


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated default language setting for the application from Japanese to English, enhancing localization support.
  - Simplified structure of the indicators component by providing direct access to an array of indicator constants.

- **Bug Fixes**
  - Removed reliance on a functional component for indicators, ensuring consistent behavior and easier modifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->