### PR TITLE
日本語化対応（テーブルヘッダー）

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -80,8 +80,24 @@
         "blocksValidated": "Blocks validated",
         "logs": "Logs",
         "contract": "Contract",
+        "addresse": "Addresse",
         "backToTopAccountsList": "Back to top accounts list",
         "details": "details"
+    },
+    "tokenTransferTable": {
+        "token": "Token",
+        "tokenId": "Token ID",
+        "txnHash": "Txn hash",
+        "fromTo": "From/To",
+        "value": "Value"
+    },
+    "txsTable": {
+        "txnHash": "Txn hash",
+        "type": "Type",
+        "method": "Method",
+        "block": "Block",
+        "fromTo": "From/To",
+        "value": "Value",
+        "fee": "Fee"
     }
-      
 }

--- a/public/locales/ja/translation.json
+++ b/public/locales/ja/translation.json
@@ -80,7 +80,24 @@
         "blocksValidated": "検証済みブロック",
         "logs": "ログ",
         "contract": "コントラクト",
+        "addresse": "アドレス",
         "backToTopAccountsList": "トップアカウントリストに戻る",
         "details": "詳細"
+    },
+    "tokenTransferTable": {
+        "token": "トークン",
+        "tokenId": "トークンID",
+        "txnHash": "取引ハッシュ",
+        "fromTo": "送信者/受信者",
+        "value": "値"
+    },
+    "txsTable": {
+        "txnHash": "取引ハッシュ",
+        "type": "タイプ",
+        "method": "メソッド",
+        "block": "ブロック",
+        "fromTo": "送信者/受信者",
+        "value": "Value",
+        "fee": "手数料"
     }
 }      

--- a/ui/shared/TokenTransfer/TokenTransferTable.tsx
+++ b/ui/shared/TokenTransfer/TokenTransferTable.tsx
@@ -1,5 +1,6 @@
 import { Table, Tbody, Tr, Th } from '@chakra-ui/react';
 import React from 'react';
+import { useTranslation } from 'react-i18next';
 
 import type { TokenTransfer } from 'types/api/tokenTransfer';
 
@@ -31,6 +32,7 @@ const TokenTransferTable = ({
   socketInfoNum,
   isLoading,
 }: Props) => {
+  const { t } = useTranslation();
 
   return (
     <AddressHighlightProvider>
@@ -38,11 +40,11 @@ const TokenTransferTable = ({
         <Thead top={ top }>
           <Tr>
             { showTxInfo && <Th width="44px"></Th> }
-            <Th width="230px">Token</Th>
-            <Th width="160px">Token ID</Th>
-            { showTxInfo && <Th width="200px">Txn hash</Th> }
-            <Th width="60%">From/To</Th>
-            <Th width="40%" isNumeric>Value</Th>
+            <Th width="230px">{ t('tokenTransferTable.token') }</Th>
+            <Th width="160px">{ t('tokenTransferTable.tokenId') }</Th>
+            { showTxInfo && <Th width="200px">{ t('tokenTransferTable.txnHash') }</Th> }
+            <Th width="60%">{ t('tokenTransferTable.fromTo') }</Th>
+            <Th width="40%" isNumeric>{ t('tokenTransferTable.value') }</Th>
           </Tr>
         </Thead>
         <Tbody>

--- a/ui/txs/TxsTable.tsx
+++ b/ui/txs/TxsTable.tsx
@@ -1,6 +1,7 @@
 import { Link, Table, Tbody, Tr, Th } from '@chakra-ui/react';
 import { AnimatePresence } from 'framer-motion';
 import React from 'react';
+import { useTranslation } from 'react-i18next';
 
 import type { Transaction, TransactionsSortingField, TransactionsSortingValue } from 'types/api/transaction';
 
@@ -41,6 +42,7 @@ const TxsTable = ({
   enableTimeIncrement,
   isLoading,
 }: Props) => {
+  const { t } = useTranslation();
   const { cutRef, renderedItemsNum } = useLazyRenderedList(txs, !isLoading);
 
   const feeCurrency = config.UI.views.tx.hiddenFields?.fee_currency || config.chain.hasMultipleGasCurrencies ?
@@ -53,17 +55,17 @@ const TxsTable = ({
         <TheadSticky top={ top }>
           <Tr>
             <Th width="54px"></Th>
-            <Th width="180px">Txn hash</Th>
-            <Th width="160px">Type</Th>
-            <Th width="20%">Method</Th>
-            { showBlockInfo && <Th width="18%">Block</Th> }
-            <Th width="224px">From/To</Th>
+            <Th width="180px">{ t('txsTable.txnHash') }</Th>
+            <Th width="160px">{ t('txsTable.type') }</Th>
+            <Th width="20%">{ t('txsTable.method') }</Th>
+            { showBlockInfo && <Th width="18%">{ t('txsTable.block') }</Th> }
+            <Th width="224px">{ t('txsTable.fromTo') }</Th>
             { !config.UI.views.tx.hiddenFields?.value && (
               <Th width="20%" isNumeric>
                 <Link onClick={ sort('value') } display="flex" justifyContent="end">
                   { sorting === 'value-asc' && <IconSvg boxSize={ 5 } name="arrows/east" transform="rotate(-90deg)"/> }
                   { sorting === 'value-desc' && <IconSvg boxSize={ 5 } name="arrows/east" transform="rotate(90deg)"/> }
-                  { `Value ${ currencyUnits.ether }` }
+                  { `${ t('txsTable.value') } ${ currencyUnits.ether }` }
                 </Link>
               </Th>
             ) }
@@ -72,7 +74,7 @@ const TxsTable = ({
                 <Link onClick={ sort('fee') } display="flex" justifyContent="end">
                   { sorting === 'fee-asc' && <IconSvg boxSize={ 5 } name="arrows/east" transform="rotate(-90deg)"/> }
                   { sorting === 'fee-desc' && <IconSvg boxSize={ 5 } name="arrows/east" transform="rotate(90deg)"/> }
-                  { `Fee${ feeCurrency }` }
+                  { `${ t('txsTable.fee') }${ feeCurrency }` }
                 </Link>
               </Th>
             ) }


### PR DESCRIPTION
## Description and Related Issue(s)

*[Provide a brief description of the changes or enhancements introduced by this pull request and explain motivation behind them. Cite any related issue(s) or bug(s) that it addresses using the [format](https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/) `Fixes #123` or `Resolves #456`.]*

### Proposed Changes
*[Specify the changes or additions made in this pull request. Please mention if any changes were made to the ENV variables]*

### Breaking or Incompatible Changes
*[Describe any breaking or incompatible changes introduced by this pull request. Specify how users might need to modify their code or configurations to accommodate these changes.]*

### Additional Information
*[Include any additional information, context, or screenshots that may be helpful for reviewers.]*

## Checklist for PR author
- [ ] I have tested these changes locally.
- [ ] I added tests to cover any new functionality, following this [guide](./CONTRIBUTING.md#writing--running-tests)
- [ ] Whenever I fix a bug, I include a regression test to ensure that the bug does not reappear silently.
- [ ] If I have added, changed, renamed, or removed an environment variable
    - I updated the list of environment variables in the [documentation](ENVS.md) 
    - I made the necessary changes to the validator script according to the [guide](./CONTRIBUTING.md#adding-new-env-variable)
    - I added "ENVs" label to this pull request


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced localization support with new translations for token transfer and transaction details in both English and Japanese.
  - Added new sections in translation files for "tokenTransferTable" and "txsTable" to improve multilingual capabilities.

- **Improvements**
  - Integrated internationalization support in the Token Transfer and Transactions tables, enabling dynamic text rendering based on user-selected languages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->