### PR TITLE
日本語化対応と一部誤字修正

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -80,7 +80,7 @@
         "blocksValidated": "Blocks validated",
         "logs": "Logs",
         "contract": "Contract",
-        "addresse": "Addresse",
+        "address": "Address",
         "backToTopAccountsList": "Back to top accounts list",
         "details": "details"
     },
@@ -99,5 +99,11 @@
         "fromTo": "From/To",
         "value": "Value",
         "fee": "Fee"
+    },
+    "tokensTable": {
+        "token": "Token",
+        "price": "Price",
+        "onChainMarketCap": "On-chain market cap",
+        "holders": "Holders"
     }
 }

--- a/public/locales/ja/translation.json
+++ b/public/locales/ja/translation.json
@@ -80,7 +80,7 @@
         "blocksValidated": "検証済みブロック",
         "logs": "ログ",
         "contract": "コントラクト",
-        "addresse": "アドレス",
+        "address": "アドレス",
         "backToTopAccountsList": "トップアカウントリストに戻る",
         "details": "詳細"
     },
@@ -99,5 +99,11 @@
         "fromTo": "送信者/受信者",
         "value": "Value",
         "fee": "手数料"
+    },
+    "tokensTable": {
+        "token": "トークン",
+        "price": "価格",
+        "onChainMarketCap": "オンチェーン時価総額",
+        "holders": "ホルダー"
     }
 }      

--- a/ui/tokens/TokensTable.tsx
+++ b/ui/tokens/TokensTable.tsx
@@ -1,5 +1,6 @@
 import { Link, Table, Tbody, Th, Tr } from '@chakra-ui/react';
 import React from 'react';
+import { useTranslation } from 'react-i18next';
 
 import type { TokenInfo } from 'types/api/token';
 import type { TokensSortingField, TokensSortingValue } from 'types/api/tokens';
@@ -29,6 +30,7 @@ type Props = {
 }
 
 const TokensTable = ({ items, page, isLoading, sorting, setSorting, top }: Props) => {
+  const { t } = useTranslation();
   const sortIconTransform = sorting?.includes('asc') ? 'rotate(-90deg)' : 'rotate(90deg)';
 
   const sort = React.useCallback((field: TokensSortingField) => () => {
@@ -40,23 +42,23 @@ const TokensTable = ({ items, page, isLoading, sorting, setSorting, top }: Props
     <Table>
       <Thead top={ top ?? ACTION_BAR_HEIGHT_DESKTOP }>
         <Tr>
-          <Th w="50%">Token</Th>
+          <Th w="50%">{ t('tokensTable.token') }</Th>
           <Th isNumeric w="15%">
             <Link onClick={ sort('fiat_value') } display="flex" justifyContent="end">
               { sorting?.includes('fiat_value') && <IconSvg name="arrows/east-mini" boxSize={ 4 } transform={ sortIconTransform }/> }
-              Price
+              { t('tokensTable.price') }
             </Link>
           </Th>
           <Th isNumeric w="20%">
             <Link onClick={ sort('circulating_market_cap') } display="flex" justifyContent="end">
               { sorting?.includes('circulating_market_cap') && <IconSvg name="arrows/east-mini" boxSize={ 4 } transform={ sortIconTransform }/> }
-              On-chain market cap
+              { t('tokensTable.onChainMarketCap') }
             </Link>
           </Th>
           <Th isNumeric w="15%">
             <Link onClick={ sort('holder_count') } display="flex" justifyContent="end">
               { sorting?.includes('holder_count') && <IconSvg name="arrows/east-mini" boxSize={ 4 } transform={ sortIconTransform }/> }
-              Holders
+              { t('tokensTable.holders') }
             </Link>
           </Th>
         </Tr>


### PR DESCRIPTION
## Description and Related Issue(s)

*[Provide a brief description of the changes or enhancements introduced by this pull request and explain motivation behind them. Cite any related issue(s) or bug(s) that it addresses using the [format](https://blog.github.com/2013-05-14-closing-issues-via-pull-requests/) `Fixes #123` or `Resolves #456`.]*

### Proposed Changes
*[Specify the changes or additions made in this pull request. Please mention if any changes were made to the ENV variables]*

### Breaking or Incompatible Changes
*[Describe any breaking or incompatible changes introduced by this pull request. Specify how users might need to modify their code or configurations to accommodate these changes.]*

### Additional Information
*[Include any additional information, context, or screenshots that may be helpful for reviewers.]*

## Checklist for PR author
- [ ] I have tested these changes locally.
- [ ] I added tests to cover any new functionality, following this [guide](./CONTRIBUTING.md#writing--running-tests)
- [ ] Whenever I fix a bug, I include a regression test to ensure that the bug does not reappear silently.
- [ ] If I have added, changed, renamed, or removed an environment variable
    - I updated the list of environment variables in the [documentation](ENVS.md) 
    - I made the necessary changes to the validator script according to the [guide](./CONTRIBUTING.md#adding-new-env-variable)
    - I added "ENVs" label to this pull request


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced localization support for token-related terms, including "Token," "Price," "On-chain market cap," and "Holders" in both English and Japanese.
  
- **Bug Fixes**
  - Corrected the term "Addresse" to "Address" in translation files for improved accuracy.

- **Improvements**
  - Enhanced the `TokensTable` component to support internationalization, allowing dynamic translations based on user language preferences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->